### PR TITLE
amendment of jsdoc section

### DIFF
--- a/chapters/ch04-logtar-our-logging-library.md
+++ b/chapters/ch04-logtar-our-logging-library.md
@@ -633,13 +633,13 @@ Let's fix it.
     }
 ```
 
-We create `jsdoc` comments with multi-line comment format using `/** ... */`. Then specify a tag using `@`. In the code snippet above, we specified two tags - `@params` and `@returns`. The tags have the following syntax
+We create `jsdoc` comments with multi-line comment format using `/** ... */`. Then specify a tag using `@`. In the code snippet above, we specified three tags - `@params`, `@returns` and `@throws`. The tags have the following syntax
 
 ```textile
 @tag {Type} <argument> <description>
 ```
 
-The `Type` is the actual type of the `argument` you specified. that you're referring to. In our case it's the argument for `with_max_file_size` method is `max_file_size`. And the type for that is `number`. The description is the documentation part for that particular parameter.
+The `Type` is the actual type of the `argument` that you're referring to. In our case it's the argument `file_prefix` in the method `with_file_prefix`. The type for that is `string`. The description is the documentation part for that particular parameter.
 
 Here's the `jsdoc` comments with `with_log_level` method
 


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter:
4

## Section Title:
4.8 - jsdoc comments

The text below the code example `with_file_prefix` refers to `max_file_size`. The current text explanation doesn't match the code block directly above it. I made some amendments to the text to reflect this.

I hope this is correct, and I apologise for steaming ahead like this.