### PR TITLE
Update ch04-logtar-our-logging-library.md

### DIFF
--- a/chapters/ch04-logtar-our-logging-library.md
+++ b/chapters/ch04-logtar-our-logging-library.md
@@ -758,14 +758,14 @@ class RollingConfig {
     // If yes, set the size, and return the current instance of the class.
     // If it's not valid, throw an error.
     with_size_threshold(size_threshold) {
-        RollingTimeOptions.assert_size(size_threshold);
+        RollingSizeOptions.assert(size_threshold);
         this.#size_threshold = size_threshold;
         return this;
     }
 
     // Same like above, but with `time`.
     with_time_threshold(time_threshold) {
-        RollingTimeOptions.assert_time(time_threshold);
+        RollingTimeOptions.assert(time_threshold);
         this.#time_threshold = time_threshold;
         return this;
     }


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter:
4

## Section Title:
4.10 - Finishing up the RollingConfig class

`with_time_threshold` and `with_time_threshold` updated to reflect the `assert` methods of `RollingTimeOptions` and `RollingSizeOptions`. The code in `code/chapter_04.0` is correct, but the tutorial text has not accounted for this. 

In the tutorial, `assert_time` and `assert_size` are not valid methods.