### PR TITLE
Update ch04.2-writing-logs.md

### DIFF
--- a/chapters/ch04.2-writing-logs.md
+++ b/chapters/ch04.2-writing-logs.md
@@ -488,7 +488,7 @@ And then call the `init` method from the `test.js`
 const { Logger, LogConfig } = require("./index");
 
 const logger = Logger.with_config(LogConfig.from_file("./config.json"));
-await logger.init();
+logger.init();
 console.log("Program exits.");
 ```
 
@@ -496,8 +496,8 @@ However the output is strange
 
 ```bash
 ### outputs
-End of the file
-Finished creating a file and opening
+Program exits.
+File created.
 ```
 
 Why is it so? It is because we're using the `node:fs/promises` module, where all the functions are asynchronous. That means, they do not block any code and continue execution without waiting. This is the key to creating performant concurrent applications.

--- a/chapters/ch04.2-writing-logs.md
+++ b/chapters/ch04.2-writing-logs.md
@@ -426,7 +426,7 @@ There's a lot going on in this method. Let's break it down.
 
 3. `new Date().toISOString()` generates a string representation of the current date and time in the ISO 8601 format, such as "2023-08-18T15:30:00.000Z".
 
-4. `.replace(/[\.:]+/, "")` is a regular expression operation. Let's break down the regex:
+4. `.replace(/[\..*]/, "")` is a regular expression operation. Let's break down the regex:
 
     - the square brackets [] are used to define a character class. A character class is a way to specify a set of characters from which a single character can match. For example:
         - [abc] matches any single character that is either 'a', 'b', or 'c'.
@@ -435,17 +435,13 @@ There's a lot going on in this method. Let's break it down.
         
             You can also use special characters within character classes to match certain character types, like `\d` for digits, `\w` for word characters, `\s` for whitespace, etc.
 
-            In this case we are looking for all the dot (`.`) characters and colon (`:`) characters in the string.
+            In this case we are looking for the dot character and every character after it until the end of the string. 
 
-    - `\.` matches a literal dot character. Since the dot (`.`) is a special character in regular expression, known as a wildcard. It matches any single character except for a newline character (`\n`). This is useful when you want to match any character, which is often used in pattern matching.
+    - `\.` matches a literal dot character, since the dot alone (`.`) is a special character in regular expression, known as a wildcard. It matches any single character except for a newline character (`\n`). This is useful when you want to match any character, which is often used in pattern matching.
 
         However, in this case, we want to match a literal dot character in the string (the dot in the date-time format "00.000Z"). To achieve this, we need to escape the dot character by preceding it with a backslash (`\`). When you place a backslash before a special character, it indicates that you want to match the literal character itself, rather than its special meaning.
 
-    - `+` matches one or more of any character except newline. We match for all the characters following the dot (.) and the (:) character.
-
-    - `/g` is the global flag, indicating that the replacement should be applied to all occurrences of the pattern.
-
-    - So, the regex `[\.:]+` matches the dot or colon and all the repeated occurences of these 2 characters.
+    - `.*` is using the `.` in its wildcard capacity, to match any character. The `*` matches the previous character 0 or more times. So together, this matches the entire remaining part of the string.
 
     - The replacement `""` removes the dot and all characters after it.
 

--- a/chapters/ch04.2-writing-logs.md
+++ b/chapters/ch04.2-writing-logs.md
@@ -410,7 +410,7 @@ class Logger {
     #log_file_handle;
 
     async init() {
-         const file_name = this.#config.file_prefix + new Date().toISOString().replace(/[\.:]+/, "-") + ".log";
+         const file_name = this.#config.file_prefix + new Date().toISOString().replace(/\..*/, "") + ".log";
         this.#log_file_handle = await fs.open(file_name, "a+");
     }
 }

--- a/code/chapter_04.2/lib/logger.js
+++ b/code/chapter_04.2/lib/logger.js
@@ -28,7 +28,7 @@ class Logger {
     async init() {
           const log_dir_path = check_and_create_dir("logs")
 
-          const file_name = this.#config.file_prefix + new Date().toISOString().replace(/[\.:]+/, "-") + ".log";
+          const file_name = this.#config.file_prefix + new Date().toISOString().replace(/\..*/, "") + ".log";
           this.#log_file_handle = await fs.open(path.join(log_dir_path, file_name), "a+");
     }
 


### PR DESCRIPTION
Make regex match the intended output.

## Is this issue already raised? 
No

## Chapter:
04.2

## Section Title:
Writing to a file

## Topic:
`init()` method

The regex provided does not match the output.

**To Reproduce**
```javascript
const file_name = "LogTar_" + new Date().toISOString().replace(/[\.:]+/, "-") + ".log";
console.log(file_name) // LogTar_2023-09-20T07-49:23.207Z.log
```
**Expected behavior**
Output should match `LogTar_2023-08-18T17:20:23.log`.
