### PR TITLE
docs: typo on comment

### DIFF
--- a/chapters/ch03-working-with-files.md
+++ b/chapters/ch03-working-with-files.md
@@ -642,7 +642,7 @@ async function read_file() {
             console.log("File handle %d closed", file_handle.fd);
         });
 
-        // The 'line' event be fired whenver a line is read from the file.
+        // The 'line' event be fired whenever a line is read from the file.
         stream.on("line", (line) => {
             console.log("Getting line -> %s", line);
         });


### PR DESCRIPTION
Just fixed a single letter on the docs that was written wrong!

## Is this issue already raised? No

## Chapter: 3 Working with files

## Section Title: Reading from a file

## Topic: Files
