### PR TITLE
Fixed example in  ch03-working-with-files.md

### DIFF
--- a/chapters/ch03-working-with-files.md
+++ b/chapters/ch03-working-with-files.md
@@ -386,7 +386,7 @@ The `flag` argument indicates the mode (not to confused by `mode` argument) in w
 Let’s use `wx+` to show a small example. `wx+` will open a file for read and write, but fail to open a file if it already exists. If the file doesn’t exists it will create a file and work just fine.
 
 ```jsx
-// calculator.js
+// files.js
 const file_handle = await fs.open(
     "calculator.js",
     "wx+",


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter: 3 working-with-files

## Section Title: `fs module`

## Topic: 

`pathLink Modes`, here we are demonstrating the `wx+` mode, we are trying to open and write `calculator.js` file, but the comment is suggesting that the changes are being made to `calculator.js` file when it should be in `files.js` file.

