### PR TITLE
Fixed `Read Next` path (5.4)

### DIFF
--- a/chapters/ch05.4-headers.md
+++ b/chapters/ch05.4-headers.md
@@ -350,4 +350,4 @@ An example response using `Set-Cookie`:
 Set-Cookie: userprefs=language=en; currency=INR; expires=Thu, 31 Dec 2023 23:59:59 GMT; Path=/; Secure; HttpOnly
 ```
 
-[![Read Prev](/assets/imgs/prev.png)](/chapters/ch05.5-the-response.md)
+[![Read Next](/assets/imgs/next.png)](/chapters/ch05.5-response-status-codes.md)


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter: 5

## Section Title: Headers

## Topic:
Changed the bottom button to `Read Next`, and fixed the chapter path.