### PR TITLE
added setter function in Router class

### DIFF
--- a/chapters/ch06.3-improving-the-router-api.md
+++ b/chapters/ch06.3-improving-the-router-api.md
@@ -45,12 +45,19 @@ class Router {
         this.routes = {}
     }
 
+#set(key,value){
+    this.routes[key] = value
+}
+
     #addRoute(method, path, handler) {
         if (typeof path !== "string" || typeof handler !== "function") {
             throw new Error("Invalid argument types: path must be a string and handler must be a function");
         }
+        
+        this.#set(`${method} ${path}`, handler);
 
-        this.routes.set(`${method} ${path}`, handler);
+        //or just add the value directly
+        // this.routes[`${method} ${path}] = handler;
     }
 
     get(path, handler) {


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter:
6

## Section Title:
6.3 Improving the Router API

## Topic:
Since we are using `this.routes.set()`  to set the handler, I also defined a setter method in the class, and since it's only going to be useful inside the class, I made it private. 

or we can go with the previous version `this.routes[`${method} ${path}`] = handler`.
