### PR TITLE
fix(chapters): correct a logic in code example in ch04.0

### DIFF
--- a/chapters/ch04.0-logtar-our-logging-library.md
+++ b/chapters/ch04.0-logtar-our-logging-library.md
@@ -115,10 +115,10 @@ class LogLevel {
 
     static assert(log_level) {
        if (
-            log_level !== LogLevel.Debug ||
-            log_level !== LogLevel.Info ||
-            log_level !== LogLevel.Warn ||
-            log_level !== LogLevel.Error ||
+            log_level !== LogLevel.Debug &&
+            log_level !== LogLevel.Info &&
+            log_level !== LogLevel.Warn &&
+            log_level !== LogLevel.Error &&
             log_level !== LogLevel.Critical
         ) {
             throw new Error(


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter: ch04

## Section Title:  Creating a `LogLevel` class

## Topic: logtar-our-logging-library

The assert method's condition should use `&&` (AND) instead of `||` (OR). Using `&&` will correctly check if the `log_level` is not equal to any of the valid log levels.
