### PR TITLE
fix(chapters): fix a wrong param in example code in ch06.10

### DIFF
--- a/chapters/ch06.10-running-our-server.md
+++ b/chapters/ch06.10-running-our-server.md
@@ -149,7 +149,7 @@ function run(router, port) {
   }
 
   createServer(function _create(req, res) {
-    const route = router.findRoute(req.url, req.path);
+    const route = router.findRoute(req.url, req.method);
 
     if (route?.handler) {
       req.params = route.params;
@@ -195,7 +195,7 @@ createServer(function _create(req, res) { ... }).listen(port);
 We're creating an HTTP server using the `createServer` function. To re-iterate, the `createServer` function takes a single argument\*, which is a callback function. The callback function will receive two arguments: `req` (the `Http.IncomingMessage` object) and `res` (the `Http.ServerResponse` object).
 
 ```js
-const route = router.findRoute(req.url, req.path);
+const route = router.findRoute(req.url, req.method);
 
 if (route?.handler) {
   req.params = route.params;


### PR DESCRIPTION
## Is this issue already raised? No

## Chapter: ch06

## Section Title:  Running Our Server

## Topic: The run function

The second parameter passed to `router.findRoute()` should be `req.method` rather than `req.path`.