### PR TITLE
Fix: incorrect parameter name

### DIFF
--- a/chapters/ch04.2-writing-logs.md
+++ b/chapters/ch04.2-writing-logs.md
@@ -754,7 +754,7 @@ class Logger {
         }
 
         // write logs to the opened file
-        await this.#log_file_handle.write(log_message);
+        await this.#log_file_handle.write(message);
     }
     ...
 }


### PR DESCRIPTION
- incorrect parameter `log_message` was replaced by `message`

## Is this issue already raised? No

## Chapter: 04

## Section Title: Writing Logs

## Topic: Completing the log method
