### PR TITLE
Added 'use strict'; directive to Chapter 04.0 for code correctness

### DIFF
--- a/chapters/ch04.0-logtar-our-logging-library.md
+++ b/chapters/ch04.0-logtar-our-logging-library.md
@@ -340,6 +340,9 @@ module.exports = {
 Let's try to test this.
 
 ```js
+
+'use strict'; 
+
 new Logger("OK"); // throws error
 new Logger(LogLevel.Debug); // works fine
 new Logger(); // works fine


### PR DESCRIPTION
## Is this issue already raised? Yes

## Chapter: 04.0

## Section Title: Logtar - Our Logging Library

## Topic: Missing 'use strict'; directive in code example
