### PR TITLE
fix: replace incorrect jsx code fence with javascript in ch03.0

### DIFF
--- a/chapters/ch03.0-working-with-files.md
+++ b/chapters/ch03.0-working-with-files.md
@@ -35,7 +35,7 @@ Let’s see an example by creating a module called `calculate`
 
 Create a file `calculator.js` and add the following contents inside it
 
-```jsx
+```javascript
 // calculator.js
 
 function add(num_one, num_two) {
@@ -69,7 +69,7 @@ Note, we haven’t exported `multiply` and `divide` and we’ll see in a moment 
 
 In your `index.js` file, you can import the exported functions as shown below.
 
-```jsx
+```javascript
 const { add, divide, multiply, subtract } = require("./calculator");
 
 // You may also write it this way, but it's preferred to omit the `.js` extension
@@ -82,7 +82,7 @@ The `module.exports` is basically a javascript `Object`, and when you `require` 
 
 So, you can think of it as something like this:
 
-```jsx
+```javascript
 const my_module = {
     fn_one: function fn_one() {...},
     fn_two: function fn_two() {...}
@@ -98,7 +98,7 @@ This may clear up why we don't get an error if we try to include a function/prop
 
 So, the `multiply` and `divide` identifiers above are just `undefined`. However, if we try to add this line:
 
-```jsx
+```javascript
 // index.js
 
 let num_two = multiply(1, 2);
@@ -106,7 +106,7 @@ let num_two = multiply(1, 2);
 
 the program crashes:
 
-```jsx
+```javascript
 /Users/ishtmeet/Code/intro-to-node/index.js:5
 let num_two = multiply(1, 2);
               ^
@@ -125,7 +125,7 @@ We cannot invoke an `undefined` value as a function. `undefined()` doesn't make 
 
 Let’s export all the functions from the `calculator` module.
 
-```jsx
+```javascript
 // calculator.js
 
 function add(num_one, num_two) {...}
@@ -147,7 +147,7 @@ module.exports = {
 
 In the `index.js` file, call all those functions to see if everything’s working as expected.
 
-```jsx
+```javascript
 // index.js
 
 const { add, divide, multiply, subtract } = require("./calculator");
@@ -168,7 +168,7 @@ Recall what was just stated above: `module.exports` is simply an object. We only
 
 So instead of doing `module.exports = { add, subtract, .. }`, you could also do this
 
-```jsx
+```javascript
 // calculator.js
 
 module.exports.add = function add(num_one, num_two) {
@@ -192,7 +192,7 @@ It’s a matter of preference. But there’s a big downside and nuance to this a
 
 _We’ll use the term `file` and `module` interchangeably, even though they’re not actually the same in theory_
 
-```jsx
+```javascript
 // calculator.js
 module.exports.add = function add(num_one, num_two) {..}
 module.exports.subtract = function subtract(num_one, num_two) {..}
@@ -221,7 +221,7 @@ ReferenceError: divide is not defined
 
 This is because `divide` and all the other functions declared in this module are a part of `module.exports` object, and they’re not available in the scope. Let’s break it down into an easy example
 
-```jsx
+```javascript
 let person = {};
 person.get_age = function get_age() {...}
 
@@ -232,7 +232,7 @@ get_age();
 
 I hope this makes it clear. Instead you could do something like this
 
-```jsx
+```javascript
 // calculator.js
 
 ...
@@ -280,7 +280,7 @@ The `node:fs` module lets you work with the file system using standard [POSIX](h
 
 Let’s create a new module, `files.js`, in the same folder where your `calculator` module and the `index.js` file lives. Let’s import the `fs` module to start working with files.
 
-```jsx
+```javascript
 // Promise based API
 const fs = require("node:fs/promises");
 
@@ -298,7 +298,7 @@ Asynchronous code is better for managing multiple tasks happening at the same ti
 
 Inside `files.js` add this snippet of code
 
-```jsx
+```javascript
 // files.js
 const fs = require("node:fs/promises");
 
@@ -312,7 +312,7 @@ module.exports = open_file;
 
 and in `index.js`
 
-```jsx
+```javascript
 // index.js
 const open_file = require("./files");
 
@@ -331,13 +331,13 @@ FileHandle {
 
 Let’s break this down.
 
-```jsx
+```javascript
 const fs = require("node:fs/promises");
 ```
 
 This line brings in the **`fs`** module from Node.js. It specifically imports the **`fs/promises`** sub-module, which provides file system operations that can be executed asynchronously and are wrapped in Promises.
 
-```jsx
+```javascript
 fs.open("calculator.js", "r", fs.constants.O_RDONLY);
 ```
 
@@ -345,7 +345,7 @@ The **`fs.open`** function is used to open a file. It takes three arguments - fi
 
 The `path` takes an argument of type **`PathLike`** which is a type that represents a file path. It's a concept used in Node.js API to indicate that a value should be a string representing a valid file path. Let’s see the type definition of `PathLike`
 
-```jsx
+```javascript
 export type PathLike = string | Buffer | URL;
 ```
 
@@ -361,7 +361,7 @@ export type PathLike = string | Buffer | URL;
    With the **`URL`** module in Node.js, you can also represent file paths using URLs. The URL must be of scheme file.
    Example URL path:
 
-```jsx
+```javascript
 const url_path = new URL("file:///home/user/projects/calculator.js");
 ```
 
@@ -388,7 +388,7 @@ The `flag` argument indicates the mode (not to confused by `mode` argument) in w
 
 Let’s use `wx+` to show a small example. `wx+` will open a file for read and write, but fail to open a file if it already exists. If the file doesn’t exists it will create a file and work just fine.
 
-```jsx
+```javascript
 // files.js
 const file_handle = await fs.open(
     "calculator.js",
@@ -425,7 +425,7 @@ In our case, the permissions are specified as `fs.constants.O_RDONLY`. Here is a
 
 **Modes to use with `fs.open()`**
 
-```jsx
+```javascript
 /** Flag indicating to open a file for read-only access. */
 const O_RDONLY: number;
 
@@ -471,7 +471,7 @@ const O_NONBLOCK: number;
 
 Going back to the code we wrote in the `files` module
 
-```jsx
+```javascript
 // files.js
 const fs = require("node:fs/promises");
 
@@ -487,7 +487,7 @@ The return type of `fs.open()` is a `FileHandle`. A file handle is like a connec
 
 We previously discussed **file descriptors**. You can check which descriptor is assigned to an opened file.
 
-```jsx
+```javascript
 // files.js
 
 ..
@@ -504,7 +504,7 @@ async function open_file() {
 
 You may get the same integer value for the file descriptor if you try to run the program multiple times. But if you try to create another file handle, it should have a different file descriptor
 
-```jsx
+```javascript
 // files.js
 
 ..
@@ -558,7 +558,7 @@ Make sure to handle errors gracefully. There may be cases where you don't need t
 
 To catch errors, wrap the code inside a `try/catch` block.
 
-```jsx
+```javascript
 // files.js
 
 ..
@@ -589,7 +589,7 @@ Too much of the theory. We’ll work on a real example now. Let’s try to read 
 
 Add these content inside the `log_config.json` file
 
-```jsx
+```javascript
 // log_config.json
 
 {
@@ -599,7 +599,7 @@ Add these content inside the `log_config.json` file
 
 Node.js provides many utility methods for reading from a specific file using the `file_handle`. There are different ways to handle interactions with the files from the `node:fs` and the `node:fs/promises` modules. But we’re specifically going to use a `file_handle` for now.
 
-```jsx
+```javascript
 // files.js
 
 const fs = require("node:fs/promises");
@@ -688,7 +688,7 @@ We can simplify the above code. I included all possible option keys previously j
 
 The simplified version looks like this
 
-```jsx
+```javascript
 // files.js
 
 ...
@@ -743,7 +743,7 @@ Here's an overview of how the **`for..of`** loop works:
 
 Here's an example of using **`for..of`** to loop through an array:
 
-```jsx
+```javascript
 const fruits = ["apple", "banana", "orange", "grape"];
 
 for (const fruit of fruits) {
@@ -770,7 +770,7 @@ The **`for await..of`** loop is an extension of the **`for..of`** loop. It is us
 
 Here's how the **`for await..of`** loop works:
 
-```jsx
+```javascript
 for await (const element of async_iterable) {
   // Asynchronous code to be executed for each element
 }
@@ -784,7 +784,7 @@ Let's break down the key components:
 
 Here's an example of using **`for await..of`** to loop through an asynchronous iterable:
 
-```jsx
+```javascript
 async function fetch_fruits() {
   const fruits = ["apple", "banana", "orange", "grape"];
 
@@ -811,7 +811,7 @@ However, reading a json file line by line isn’t the best way. The `readLine` i
 
 Let’s update the code
 
-```jsx
+```javascript
 ...
 
 async function read_file() {
@@ -830,7 +830,7 @@ async function read_file() {
 
 Outputs
 
-```jsx
+```javascript
 [File contents] ->
  {
   "log_prefix": "[LOG]: "
@@ -839,7 +839,7 @@ Outputs
 
 Nice. But what happens, if we do not use the string substitution with `%s`?
 
-```jsx
+```javascript
 console.log("[File contents] ->\n", stream);
 ```
 
@@ -866,7 +866,7 @@ To print the json file to the console, we have 3 ways.
 
 **First method**
 
-```jsx
+```javascript
 console.log("[File contents] ->\n", stream.toString("utf-8"));
 ```
 
@@ -874,7 +874,7 @@ console.log("[File contents] ->\n", stream.toString("utf-8"));
 
 String substitution to the rescue again
 
-```jsx
+```javascript
 console.log("[File contents] ->\n %s", stream);
 ```
 
@@ -884,7 +884,7 @@ The second method is much more user friendly. They automatically serialize the b
 
 Set the `encoding` option to `utf-8`
 
-```jsx
+```javascript
 const stream = await file_handle.readFile({ encoding: "utf-8" });
 console.log("[File contents] ->\n", stream);
 ```
@@ -895,7 +895,7 @@ To read the `log_prefix` property that we specified into the `config/log_config.
 
 > Many people use the `require('file.json')` way, but there are several drawbacks to it. First, the entire file is loaded into memory when your program encounters the require statement. Second, if you update the json file during runtime, the program will still refer to the old data. It is recommended to use `require()` only when you expect the file not to change, and it is not excessively large; otherwise, it will always remain in memory.
 
-```jsx
+```javascript
 // files.js
 
 ...
@@ -913,7 +913,7 @@ console.log('Log prefix is: "%s"', config.log_prefix);
 
 This looks fine, but it is not a very good practice to specify paths like this. Using **`"./config/log_config.json"`** assumes that the **`config`** directory is located in the same directory as the current working directory of the terminal. This might not always be the case, especially if your script is being run from a different working directory, eg. from the config folder. To test this behavior, `cd config` and run `node ../index.js`
 
-```jsx
+```javascript
 Error occurred while reading file: [Error: ENOENT: no such file or directory, open './config/log_config.json'] {
   [stack]: "Error: ENOENT: no such file or directory, open './config/log_config.json'",
   [message]: "ENOENT: no such file or directory, open './config/log_config.json'",
@@ -928,7 +928,7 @@ This expects the path is relative to the current working directory, hence not wh
 
 Update the code to include the `path` module in scope
 
-```jsx
+```javascript
 // files.js
 
 const path = require('path');
@@ -949,7 +949,7 @@ Using **`__dirname`** and the **`path`** module ensures that you are referencing
 
 The full code of `files.js` looks like this now.
 
-```jsx
+```javascript
 const fs = require("node:fs/promises");
 const path = require("path");
 async function read_file() {


### PR DESCRIPTION
All code blocks in ch03.0-working-with-files.md were incorrectly tagged as ```jsx (a React syntax), but the content is plain Node.js/JavaScript. Replaced all 40 occurrences with ```javascript for correct syntax highlighting and accurate representation.

## Is this issue already raised? Yes/No

## Is this issue already raised? No
## Chapter: ch03.0-working-with-files.md
## Section Title: All sections
## Topic: Code block language hint correction (jsx → javascript)
## Section Title:

## Topic:
